### PR TITLE
Feature/sc 5 rfid card management for admin

### DIFF
--- a/SmartCharger.Business/DTOs/CardDTO.cs
+++ b/SmartCharger.Business/DTOs/CardDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace SmartCharger.Business.DTOs
+{
+    internal class CardDTO : BaseDTO
+    {
+        public string Value { get; set; }
+        public bool Active { get; set; }
+        public string Name { get; set; }
+        public UserDTO User { get; set; }
+    }
+}

--- a/SmartCharger.Business/DTOs/CardDTO.cs
+++ b/SmartCharger.Business/DTOs/CardDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace SmartCharger.Business.DTOs
 {
-    internal class CardDTO : BaseDTO
+    public class CardDTO : BaseDTO
     {
         public string Value { get; set; }
         public bool Active { get; set; }

--- a/SmartCharger.Business/DTOs/CardsResponseDTO.cs
+++ b/SmartCharger.Business/DTOs/CardsResponseDTO.cs
@@ -2,7 +2,7 @@
 
 namespace SmartCharger.Business.DTOs
 {
-    public class CardsResponseDTO
+    public class CardsResponseDTO : ResponseBaseDTO
     {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<CardDTO>? Cards { get; set; }

--- a/SmartCharger.Business/DTOs/CardsResponseDTO.cs
+++ b/SmartCharger.Business/DTOs/CardsResponseDTO.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SmartCharger.Business.DTOs
+{
+    internal class CardsResponseDTO
+    {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<CardDTO>? Cards { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public CardDTO? Card { get; set; }
+    }
+}

--- a/SmartCharger.Business/DTOs/CardsResponseDTO.cs
+++ b/SmartCharger.Business/DTOs/CardsResponseDTO.cs
@@ -2,7 +2,7 @@
 
 namespace SmartCharger.Business.DTOs
 {
-    internal class CardsResponseDTO
+    public class CardsResponseDTO
     {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<CardDTO>? Cards { get; set; }

--- a/SmartCharger.Business/DTOs/ResponseBaseDTO.cs
+++ b/SmartCharger.Business/DTOs/ResponseBaseDTO.cs
@@ -14,5 +14,11 @@ namespace SmartCharger.Business.DTOs
         
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Error { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Page { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? TotalPages { get; set; }
     }
 }

--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -1,0 +1,12 @@
+﻿using SmartCharger.Business.DTOs;
+
+namespace SmartCharger.Business.Interfaces
+{
+    public interface ICardService
+    {
+        Task<CardsResponseDTO> GetAllCards();
+        Task<CardsResponseDTO> GetCardById(int cardId);
+        Task<CardsResponseDTO> UpdateActiveStatus(int cardId);
+        Task<CardsResponseDTO> DeleteCard(int cardId);
+    }
+}

--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -4,7 +4,7 @@ namespace SmartCharger.Business.Interfaces
 {
     public interface ICardService
     {
-        Task<CardsResponseDTO> GetAllCards(int page, int pageSize);
+        Task<CardsResponseDTO> GetAllCards(int page, int pageSize, string search);
         Task<CardsResponseDTO> GetCardById(int cardId);
         Task<CardsResponseDTO> UpdateActiveStatus(int cardId);
         Task<CardsResponseDTO> DeleteCard(int cardId);

--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -4,7 +4,7 @@ namespace SmartCharger.Business.Interfaces
 {
     public interface ICardService
     {
-        Task<CardsResponseDTO> GetAllCards();
+        Task<CardsResponseDTO> GetAllCards(int page, int pageSize);
         Task<CardsResponseDTO> GetCardById(int cardId);
         Task<CardsResponseDTO> UpdateActiveStatus(int cardId);
         Task<CardsResponseDTO> DeleteCard(int cardId);

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -109,20 +109,7 @@ namespace SmartCharger.Business.Services
                 {
                     Success = true,
                     Message = "RFID card with user.",
-                    Card = new CardDTO
-                    {
-                        Id = card.Id,
-                        Value = card.Value,
-                        Active = card.Active,
-                        Name = card.Name,
-                        User = new UserDTO
-                        {
-                            Id = card.User.Id,
-                            FirstName = card.User.FirstName,
-                            LastName = card.User.LastName,
-                            Email = card.User.Email,
-                        }
-                    }
+                    Card = MapCardToDTO(card)
                 };
             }
             catch (Exception ex)
@@ -136,15 +123,66 @@ namespace SmartCharger.Business.Services
                 };
             }
         }
+        public async Task<CardsResponseDTO> UpdateActiveStatus(int cardId)
+        {
+            try
+            {
+                var card = await _context.Cards.FirstOrDefaultAsync(c => c.Id == cardId);
 
+                if (card == null)
+                {
+                    return new CardsResponseDTO
+                    {
+                        Success = false,
+                        Message = "There is no RFID card with that ID.",
+                        Card = null
+                    };
+                }
+
+                card.Active = !card.Active;
+
+                _context.Cards.Update(card);
+                await _context.SaveChangesAsync();
+
+                return new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card active status updated.",
+                    Card = MapCardToDTO(card)
+                };
+            }
+            catch (Exception ex)
+            {
+                return new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "An error occurred.",
+                    Error = ex.Message,
+                    Card = null
+                };
+            }
+        }
         public async Task<CardsResponseDTO> DeleteCard(int cardId)
         {
             throw new NotImplementedException();
         }
-
-        public async Task<CardsResponseDTO> UpdateActiveStatus(int cardId)
+        private CardDTO MapCardToDTO(Card card)
         {
-            throw new NotImplementedException();
+            return new CardDTO
+            {
+                Id = card.Id,
+                Value = card.Value,
+                Active = card.Active,
+                Name = card.Name,
+                User = new UserDTO
+                {
+                    Id = card.User.Id,
+                    FirstName = card.User.FirstName,
+                    LastName = card.User.LastName,
+                    Email = card.User.Email,
+                }
+            };
         }
+
     }
 }

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SmartCharger.Business.DTOs;
+using SmartCharger.Business.Interfaces;
+using SmartCharger.Data;
+using SmartCharger.Data.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SmartCharger.Business.Services
+{
+    public class CardService : GenericService<Card>, ICardService
+    {
+        public CardService(SmartChargerContext context) : base(context)
+        { }
+        public async Task<CardsResponseDTO> GetAllCards()
+        {
+            try
+            {
+                var cards = await _context.Cards
+                  .OrderBy(c => c.Id)
+                  .Include(c => c.User)
+                  .Select(c => new CardDTO
+                  {
+                      Id = c.Id,
+                      Value = c.Value,
+                      Active = c.Active,
+                      Name = c.Name,
+                      User = new UserDTO
+                      {
+                          Id = c.User.Id,
+                          FirstName = c.User.FirstName,
+                          LastName = c.User.LastName,
+                          Email = c.User.Email,
+                      }
+                  }).ToListAsync();
+
+                return new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "List of RFID cards with users",
+                    Cards = cards
+                };
+            }
+            catch (Exception ex)
+            {
+                return new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "An error occurred: " + ex.Message + ".",
+                    Cards = null
+                };
+            }
+        }
+        public async Task<CardsResponseDTO> GetCardById(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<CardsResponseDTO> DeleteCard(int cardId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<CardsResponseDTO> UpdateActiveStatus(int cardId)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -149,7 +149,7 @@ namespace SmartCharger.Business.Services
                 return new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "RFID card active status updated.",
+                    Message = "RFID card with id " + cardId + " updated to " + card.Active + ".",
                     Card = MapCardToDTO(card)
                 };
             }
@@ -166,7 +166,42 @@ namespace SmartCharger.Business.Services
         }
         public async Task<CardsResponseDTO> DeleteCard(int cardId)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var card = await _context.Cards
+                    .Include(c => c.User)
+                    .FirstOrDefaultAsync(c => c.Id == cardId);
+
+                if (card == null)
+                {
+                    return new CardsResponseDTO
+                    {
+                        Success = false,
+                        Message = "There is no RFID card with that ID.",
+                        Card = null
+                    };
+                }
+
+                _context.Cards.Remove(card);
+                await _context.SaveChangesAsync();
+
+                return new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with id " + cardId + " deleted.",
+                    Card = null
+                };
+            }
+            catch (Exception ex)
+            {
+                return new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "An error occurred.",
+                    Error = ex.Message,
+                    Card = null
+                };
+            }
         }
         private CardDTO MapCardToDTO(Card card)
         {

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -87,13 +87,13 @@ namespace SmartCharger.Business.Services
                 };
             }
         }
-        public async Task<CardsResponseDTO> GetCardById(int id)
+        public async Task<CardsResponseDTO> GetCardById(int cardId)
         {
             try
             {
                 var card = await _context.Cards
                     .Include(c => c.User)
-                    .FirstOrDefaultAsync(c => c.Id == id);
+                    .FirstOrDefaultAsync(c => c.Id == cardId);
 
                 if (card == null)
                 {
@@ -127,7 +127,9 @@ namespace SmartCharger.Business.Services
         {
             try
             {
-                var card = await _context.Cards.FirstOrDefaultAsync(c => c.Id == cardId);
+                var card = await _context.Cards
+                    .Include(c => c.User)
+                    .FirstOrDefaultAsync(c => c.Id == cardId);
 
                 if (card == null)
                 {

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -15,13 +15,25 @@ namespace SmartCharger.Business.Services
     {
         public CardService(SmartChargerContext context) : base(context)
         { }
-        public async Task<CardsResponseDTO> GetAllCards(int page = 1, int pageSize = 20)
+        public async Task<CardsResponseDTO> GetAllCards(int page = 1, int pageSize = 20, string search = null)
         {
             try
             {
-                var totalItems = await _context.Cards.CountAsync();
+                IQueryable<Card> query = _context.Cards;
 
-                var cards = await _context.Cards
+                if (!string.IsNullOrEmpty(search))
+                {
+                    query = query.Where(c =>
+                        c.User.FirstName.Contains(search) ||
+                        c.User.LastName.Contains(search) ||
+                        c.Name.Contains(search) ||
+                        c.Value.Contains(search)
+                    );
+                }
+
+                var totalItems = await query.CountAsync();
+
+                var cards = await query
                     .OrderBy(c => c.Id)
                     .Include(c => c.User)
                     .Skip((page - 1) * pageSize)

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -15,33 +15,41 @@ namespace SmartCharger.Business.Services
     {
         public CardService(SmartChargerContext context) : base(context)
         { }
-        public async Task<CardsResponseDTO> GetAllCards()
+        public async Task<CardsResponseDTO> GetAllCards(int page = 1, int pageSize = 20)
         {
             try
             {
+                var totalItems = await _context.Cards.CountAsync();
+
                 var cards = await _context.Cards
-                  .OrderBy(c => c.Id)
-                  .Include(c => c.User)
-                  .Select(c => new CardDTO
-                  {
-                      Id = c.Id,
-                      Value = c.Value,
-                      Active = c.Active,
-                      Name = c.Name,
-                      User = new UserDTO
-                      {
-                          Id = c.User.Id,
-                          FirstName = c.User.FirstName,
-                          LastName = c.User.LastName,
-                          Email = c.User.Email,
-                      }
-                  }).ToListAsync();
+                    .OrderBy(c => c.Id)
+                    .Include(c => c.User)
+                    .Skip((page - 1) * pageSize)
+                    .Take(pageSize)
+                    .Select(c => new CardDTO
+                    {
+                        Id = c.Id,
+                        Value = c.Value,
+                        Active = c.Active,
+                        Name = c.Name,
+                        User = new UserDTO
+                        {
+                            Id = c.User.Id,
+                            FirstName = c.User.FirstName,
+                            LastName = c.User.LastName,
+                            Email = c.User.Email,
+                        }
+                    }).ToListAsync();
+
+                var totalPages = (int)Math.Ceiling(totalItems / (double)pageSize);
 
                 return new CardsResponseDTO
                 {
                     Success = true,
                     Message = "List of RFID cards with users",
-                    Cards = cards
+                    Cards = cards,
+                    Page = page,
+                    TotalPages = totalPages
                 };
             }
             catch (Exception ex)

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -89,7 +89,52 @@ namespace SmartCharger.Business.Services
         }
         public async Task<CardsResponseDTO> GetCardById(int id)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var card = await _context.Cards
+                    .Include(c => c.User)
+                    .FirstOrDefaultAsync(c => c.Id == id);
+
+                if (card == null)
+                {
+                    return new CardsResponseDTO
+                    {
+                        Success = false,
+                        Message = "There is no RFID card with that ID.",
+                        Card = null
+                    };
+                }
+
+                return new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with user.",
+                    Card = new CardDTO
+                    {
+                        Id = card.Id,
+                        Value = card.Value,
+                        Active = card.Active,
+                        Name = card.Name,
+                        User = new UserDTO
+                        {
+                            Id = card.User.Id,
+                            FirstName = card.User.FirstName,
+                            LastName = card.User.LastName,
+                            Email = card.User.Email,
+                        }
+                    }
+                };
+            }
+            catch (Exception ex)
+            {
+                return new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "An error occurred.",
+                    Error = ex.Message,
+                    Card = null
+                };
+            }
         }
 
         public async Task<CardsResponseDTO> DeleteCard(int cardId)

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -23,15 +23,29 @@ namespace SmartCharger.Business.Services
 
                 if (!string.IsNullOrEmpty(search))
                 {
+                    string searchLower = search.ToLower();
+
                     query = query.Where(c =>
-                        c.User.FirstName.Contains(search) ||
-                        c.User.LastName.Contains(search) ||
-                        c.Name.Contains(search) ||
-                        c.Value.Contains(search)
+                        c.User.FirstName.ToLower().Contains(search) ||
+                        c.User.LastName.ToLower().Contains(search) ||
+                        c.Name.ToLower().Contains(search) ||
+                        c.Value.ToLower().Contains(search)
                     );
                 }
 
                 var totalItems = await query.CountAsync();
+
+                var totalPages = (int)Math.Ceiling(totalItems / (double)pageSize);
+
+                if (totalItems == 0 || page > totalPages)
+                {
+                    return new CardsResponseDTO
+                    {
+                        Success = false,
+                        Message = "There are no RFID cards with that parameters.",
+                        Cards = null
+                    };
+                }
 
                 var cards = await query
                     .OrderBy(c => c.Id)
@@ -53,12 +67,10 @@ namespace SmartCharger.Business.Services
                         }
                     }).ToListAsync();
 
-                var totalPages = (int)Math.Ceiling(totalItems / (double)pageSize);
-
                 return new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "List of RFID cards with users",
+                    Message = "List of RFID cards with users.",
                     Cards = cards,
                     Page = page,
                     TotalPages = totalPages
@@ -69,7 +81,8 @@ namespace SmartCharger.Business.Services
                 return new CardsResponseDTO
                 {
                     Success = false,
-                    Message = "An error occurred: " + ex.Message + ".",
+                    Message = "An error occurred.",
+                    Error = ex.Message,
                     Cards = null
                 };
             }

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -149,7 +149,7 @@ namespace SmartCharger.Business.Services
                 return new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "RFID card with id " + cardId + " updated to " + card.Active + ".",
+                    Message = "RFID card with ID:" + cardId + " updated to " + card.Active + ".",
                     Card = MapCardToDTO(card)
                 };
             }
@@ -188,7 +188,7 @@ namespace SmartCharger.Business.Services
                 return new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "RFID card with id " + cardId + " deleted.",
+                    Message = "RFID card with ID:" + cardId + " is deleted.",
                     Card = null
                 };
             }

--- a/SmartCharger.Data/Entities/Card.cs
+++ b/SmartCharger.Data/Entities/Card.cs
@@ -6,6 +6,7 @@ namespace SmartCharger.Data.Entities
     {
         public string Value { get; set; }
         public bool Active { get; set; }
+        public string Name { get; set; }
 
         [ForeignKey(nameof(User))]
         public int UserId { get; set; }

--- a/SmartCharger.Data/Migrations/20231115080038_addedNameToCard.Designer.cs
+++ b/SmartCharger.Data/Migrations/20231115080038_addedNameToCard.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartCharger.Data;
@@ -11,9 +12,11 @@ using SmartCharger.Data;
 namespace SmartCharger.Data.Migrations
 {
     [DbContext(typeof(SmartChargerContext))]
-    partial class SmartChargerContextModelSnapshot : ModelSnapshot
+    [Migration("20231115080038_addedNameToCard")]
+    partial class addedNameToCard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SmartCharger.Data/Migrations/20231115080038_addedNameToCard.cs
+++ b/SmartCharger.Data/Migrations/20231115080038_addedNameToCard.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartCharger.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class addedNameToCard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "Cards",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "Cards");
+        }
+    }
+}

--- a/SmartCharger.Test/ControllerTests/CardControllerTests.cs
+++ b/SmartCharger.Test/ControllerTests/CardControllerTests.cs
@@ -1,0 +1,286 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SmartCharger.Business.DTOs;
+using SmartCharger.Business.Interfaces;
+using SmartCharger.Controllers;
+
+namespace SmartCharger.Test.ControllerTests
+{
+    public class CardControllerTests
+    {
+        [Fact]
+        public async Task GetAllCards_WhenCardServiceReturnsSuccess_ShouldReturnOk()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.GetAllCards(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "List of RFID cards with users.",
+                    Cards = new List<CardDTO>
+                    {
+                        new CardDTO
+                        {
+                            Id = 1,
+                            Name = "Card 1",
+                            Value = "RFID-ST34-56UV-7890",
+                            Active = true,
+                            User = new UserDTO
+                            {
+                                Id = 1,
+                                FirstName = "Ivo",
+                                LastName = "Ivic",
+                                Email = "iivic@example.com"
+                            }
+                        }
+                    }
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+            
+            // Act
+            var actionResult = await controller.GetAllCards();
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("List of RFID cards with users.", response.Message);
+            Assert.Equal("1", response.Cards[0].Id.ToString());
+        }
+
+        [Fact]
+        public async Task GetAllCards_WhenCardServiceReturnsNoCards_ShouldReturnBadRequest()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.GetAllCards(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "There are no RFID cards with that parameters.",
+                    Cards = null
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.GetAllCards();
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("There are no RFID cards with that parameters.", response.Message);
+            Assert.Null(response.Cards);
+        }
+
+        [Fact]
+        public async Task GetCardById_WhenCardServiceReturnsSuccess_ShouldReturnOk()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.GetCardById(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with user.",
+                    Card = new CardDTO
+                    {
+                        Id = 1,
+                        Name = "Card 1",
+                        Value = "RFID-ST34-56UV-7890",
+                        Active = true,
+                        User = new UserDTO
+                        {
+                            Id = 1,
+                            FirstName = "Ivo",
+                            LastName = "Ivic",
+                            Email = ""
+                        }
+                    }
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.GetCardById(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("RFID card with user.", response.Message);
+            Assert.Equal("1", response.Card.Id.ToString());
+        }
+
+        [Fact]
+        public async Task GetCardById_WhenCardServiceReturnsNoCard_ShouldReturnBadRequest()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.GetCardById(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "There is no RFID card with that ID.",
+                    Card = null
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.GetCardById(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("There is no RFID card with that ID.", response.Message);
+            Assert.Null(response.Card);
+        }
+
+        [Fact]
+        public async Task UpdateActiveStatus_WhenCardServiceReturnsSuccess_ShouldReturnOk()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.UpdateActiveStatus(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with ID:1 updated to False.",
+                    Card = new CardDTO
+                    {
+                        Id = 1,
+                        Name = "Card 1",
+                        Value = "RFID-ST34-56UV-7890",
+                        Active = false,
+                        User = new UserDTO
+                        {
+                            Id = 1,
+                            FirstName = "Ivo",
+                            LastName = "Ivic",
+                            Email = ""
+                        }
+                    }
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.UpdateActiveStatus(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("RFID card with ID:1 updated to False.", response.Message);
+            Assert.Equal("1", response.Card.Id.ToString());
+            Assert.False(response.Card.Active);
+        }
+
+        [Fact]
+        public async Task UpdateActiveStatus_WhenCardServiceReturnsNoCard_ShouldReturnBadRequest()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.UpdateActiveStatus(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "There is no RFID card with that ID.",
+                    Card = null
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.UpdateActiveStatus(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("There is no RFID card with that ID.", response.Message);
+            Assert.Null(response.Card);
+        }
+
+        [Fact]
+        public async Task DeleteCard_WhenCardServiceReturnsSuccess_ShouldReturnOk()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.DeleteCard(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with ID:1 is deleted.",
+                    Card = null
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.DeleteCard(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("RFID card with ID:1 is deleted.", response.Message);
+            Assert.Null(response.Card);
+        }
+
+        [Fact]
+        public async Task DeleteCard_WhenCardServiceReturnsNoCard_ShouldReturnBadRequest()
+        {
+            // Arrange
+            var cardServiceMock = new Mock<ICardService>();
+            cardServiceMock.Setup(service => service.DeleteCard(It.IsAny<int>()))
+                .ReturnsAsync(new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "There is no RFID card with that ID.",
+                    Card = null
+                });
+
+            var controller = new CardController(cardServiceMock.Object);
+
+            // Act
+            var actionResult = await controller.DeleteCard(1);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as CardsResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("There is no RFID card with that ID.", response.Message);
+            Assert.Null(response.Card);
+        }
+    }
+}

--- a/SmartCharger.Test/ServicesTests/CardServiceTests.cs
+++ b/SmartCharger.Test/ServicesTests/CardServiceTests.cs
@@ -1,0 +1,272 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SmartCharger.Business.DTOs;
+using SmartCharger.Business.Services;
+using SmartCharger.Data;
+using SmartCharger.Data.Entities;
+
+namespace SmartCharger.Test.ServicesTests
+{
+    public class CardServiceTests
+    {
+        [Fact]
+        public async Task GetAllCards_WhenCardsExists_ShouldReturnListOfCards()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.GetAllCards();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("List of RFID cards with users.", result.Message);
+                Assert.NotNull(result.Cards);
+                Assert.Equal("1", result.Cards[0].Id.ToString());
+                Assert.Equal("RFID-ST34-56UV-7890", result.Cards[0].Value);
+                Assert.Equal("Ivo", result.Cards[0].User.FirstName);
+                Assert.Equal("Ivic", result.Cards[0].User.LastName);
+            }
+        }
+
+        [Fact]
+        public async Task GetAllCards_WhenCardsDontExist_ShouldReturnEmptyListOfCards()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "Empty")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.GetAllCards();
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("There are no RFID cards with that parameters.", result.Message);
+                Assert.Null(result.Cards);
+            }
+        }
+
+        [Fact]
+        public async Task GetCardById_WhenCardExists_ShouldReturnCard()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase2")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.GetCardById(1);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("RFID-ST34-56UV-7890", result.Card.Value);
+                Assert.Equal("Ivo", result.Card.User.FirstName);
+                Assert.Equal("Ivic", result.Card.User.LastName);
+            }
+        }
+
+        [Fact]
+        public async Task GetCardById_WhenCardDoesntExist_ShouldReturnEmpty()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "Empty")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.GetCardById(1);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("There is no RFID card with that ID.", result.Message);
+                Assert.Null(result.Cards);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateActiveStatus_WhenCardExists_ShouldReturnCard()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase3")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.UpdateActiveStatus(1);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("RFID-ST34-56UV-7890", result.Card.Value);
+                Assert.False(result.Card.Active);
+                Assert.Equal("Ivo", result.Card.User.FirstName);
+                Assert.Equal("Ivic", result.Card.User.LastName);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateActiveStatus_WhenCardDoesntExist_ShouldReturnEmpty()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "Empty")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.UpdateActiveStatus(1);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("There is no RFID card with that ID.", result.Message);
+                Assert.Null(result.Cards);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteCard_WhenCardExists_ShouldReturnSuccess()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase4")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.DeleteCard(1);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("RFID card with ID:1 is deleted.", result.Message);
+                Assert.Null(result.Card);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteCard_WhenCardDoesntExist_ShouldReturnFailure()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "Empty")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var cardService = new CardService(context);
+
+                // Act
+                CardsResponseDTO result = await cardService.DeleteCard(1);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("There is no RFID card with that ID.", result.Message);
+                Assert.Null(result.Cards);
+            }
+        }
+
+        private void SetupDatabase(SmartChargerContext context)
+        {
+            string salt = BCrypt.Net.BCrypt.GenerateSalt();
+            string hashedPassword = BCrypt.Net.BCrypt.HashPassword("password123", salt);
+
+            context.Users.Add(new User
+            {
+                Id = 1,
+                FirstName = "Ivo",
+                LastName = "Ivic",
+                Email = "iivic@example.com",
+                Password = hashedPassword,
+                Active = true,
+                CreationTime = DateTime.Now.ToUniversalTime(),
+                Salt = salt,
+                RoleId = 2
+            });
+
+            context.Users.Add(new User
+            {
+                Id = 2,
+                FirstName = "Mirko",
+                LastName = "Miric",
+                Email = "mmiric@example.com",
+                Password = hashedPassword,
+                Active = false,
+                CreationTime = DateTime.Now.ToUniversalTime(),
+                Salt = salt,
+                RoleId = 2
+            });
+
+            context.Cards.Add(new Card
+            {
+                Value = "RFID-ST34-56UV-7890",
+                Active = true,
+                Name = "Card 1",
+                UserId = 1
+            });
+
+            context.Cards.Add(new Card
+            {
+                Value = "RFID-OP56-78QR-9012",
+                Active = true,
+                Name = "Card 2",
+                UserId = 1
+            });
+
+            context.Cards.Add(new Card
+            {
+                Value = "RFID-DE32-72FJ-3821",
+                Active = true,
+                Name = "Card 1",
+                UserId = 2
+            });
+
+            context.SaveChanges();
+        }
+    }
+}

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -43,5 +43,18 @@ namespace SmartCharger.Controllers
 
             return Ok(response);
         }
+
+        [Authorize(Policy = "Admin")]
+        [HttpPatch("cards/{cardId}/active")]
+        public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> UpdateActiveStatus(int cardId)
+        {
+            CardsResponseDTO response = await _cardService.UpdateActiveStatus(cardId);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
     }
 }

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -56,5 +56,18 @@ namespace SmartCharger.Controllers
 
             return Ok(response);
         }
+
+        [Authorize(Policy = "Admin")]
+        [HttpDelete("cards/{cardId}")]
+        public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> DeleteCard(int cardId)
+        {
+            CardsResponseDTO response = await _cardService.DeleteCard(cardId);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
     }
 }

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -30,5 +30,18 @@ namespace SmartCharger.Controllers
 
             return Ok(response);
         }
+
+        [Authorize(Policy = "Admin")]
+        [HttpGet("cards/{cardId}")]
+        public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> GetCardById(int cardId)
+        {
+            CardsResponseDTO response = await _cardService.GetCardById(cardId);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
     }
 }

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SmartCharger.Business.DTOs;
+using SmartCharger.Business.Interfaces;
+using SmartCharger.Business.Services;
+
+namespace SmartCharger.Controllers
+{
+    [Route("api/admin")]
+    [ApiController]
+    public class CardController : ControllerBase
+    {
+        private readonly ICardService _cardService;
+
+        public CardController(ICardService cardService)
+        {
+            _cardService = cardService;
+        }
+
+        [Authorize(Policy = "Admin")]
+        [HttpGet("cards")]
+        public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> GetAllCards([FromQuery] int page = 1, [FromQuery] int pageSize = 20, [FromQuery] string search = null)
+        {
+            CardsResponseDTO response = await _cardService.GetAllCards(page, pageSize, search);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+    }
+}

--- a/SmartCharger/Program.cs
+++ b/SmartCharger/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddDbContext<SmartChargerContext>(option => option.UseNpgsql(bu
 builder.Services.AddScoped<IRegisterService, RegisterService>();
 builder.Services.AddScoped<ILoginService, LoginService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<ICardService, CardService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
Added RFID card management for admin. The feature allows admin to see all RFID cards, update active state of selected card and delete selected card. More info on [Confluence](https://mkajic20.atlassian.net/wiki/spaces/BaccBoysSm/pages/5308418)

Changes made:

1. Added _**'CardDTO'**_ to represent card.
2. Added _**'CardsResponseDTO'**_ which inherits 'ResponseBaseDTO' and it is used for sending JSON with list of RFID cards.
3. Implemented the _**'CardService'**_ in Bussiness layer with methods GetAllCards, GetCardById, UpdateActiveStatus and DeleteCard.
4. Implemented the _**'CardController'**_ with all endpoints.
5. Added unit tests for the _**'CardService'**_ and _**'CardController'**_ to ensure the feature works as expected.

All previous and current tests have successfully passed. ✅