### PR TITLE
Feature/sc 8 rfid card check

### DIFF
--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -14,5 +14,6 @@ namespace SmartCharger.Business.Interfaces
         Task<CardsResponseDTO> GetCardByIdForUser(int cardId, int userId);
         Task<CardsResponseDTO> AddCard(AddCardDTO card, int userId);
         Task<CardsResponseDTO> DeleteCardForUser(int cardId, int userId);
+        Task<ResponseBaseDTO> VerifyCard(int cardId);
     }
 }

--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -14,6 +14,6 @@ namespace SmartCharger.Business.Interfaces
         Task<CardsResponseDTO> GetCardByIdForUser(int cardId, int userId);
         Task<CardsResponseDTO> AddCard(AddCardDTO card, int userId);
         Task<CardsResponseDTO> DeleteCardForUser(int cardId, int userId);
-        Task<ResponseBaseDTO> VerifyCard(string cardValue);
+        Task<CardsResponseDTO> VerifyCard(string cardValue);
     }
 }

--- a/SmartCharger.Business/Interfaces/ICardService.cs
+++ b/SmartCharger.Business/Interfaces/ICardService.cs
@@ -14,6 +14,6 @@ namespace SmartCharger.Business.Interfaces
         Task<CardsResponseDTO> GetCardByIdForUser(int cardId, int userId);
         Task<CardsResponseDTO> AddCard(AddCardDTO card, int userId);
         Task<CardsResponseDTO> DeleteCardForUser(int cardId, int userId);
-        Task<ResponseBaseDTO> VerifyCard(int cardId);
+        Task<ResponseBaseDTO> VerifyCard(string cardValue);
     }
 }

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -424,9 +424,55 @@ namespace SmartCharger.Business.Services
             }
         }
 
-        public async Task<ResponseBaseDTO> VerifyCard(int cardId)
+        public async Task<ResponseBaseDTO> VerifyCard(string cardValue)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var card = await _context.Cards.FirstOrDefaultAsync(c => c.Value == cardValue);
+
+                if (card == null)
+                {
+                    return new ResponseBaseDTO
+                    {
+                        Success = false,
+                        Message = "RFID card with that value doesn't exist.",
+                    };
+                }
+
+                if (card.Active == false)
+                {
+                    return new ResponseBaseDTO
+                    {
+                        Success = false,
+                        Message = "RFID card with name " + card.Name + " is not active.",
+                    };
+                }
+
+                if (card.UsageStatus == true)
+                {
+                    return new ResponseBaseDTO
+                    {
+                        Success = false,
+                        Message = "RFID card with name " + card.Name + " is already in use.",
+                    };
+                }
+
+                return new ResponseBaseDTO
+                {
+                    Success = true,
+                    Message = "RFID card with name " + card.Name + " is accepted.",
+                };
+            }
+            catch (Exception ex)
+            {
+                return new CardsResponseDTO
+                {
+                    Success = false,
+                    Message = "An error occurred.",
+                    Error = ex.Message,
+                    Cards = null
+                };
+            }
         }
 
         private CardDTO MapCardToDTO(Card card)

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -424,6 +424,11 @@ namespace SmartCharger.Business.Services
             }
         }
 
+        public async Task<ResponseBaseDTO> VerifyCard(int cardId)
+        {
+            throw new NotImplementedException();
+        }
+
         private CardDTO MapCardToDTO(Card card)
         {
             return new CardDTO

--- a/SmartCharger.Business/Services/CardService.cs
+++ b/SmartCharger.Business/Services/CardService.cs
@@ -424,43 +424,46 @@ namespace SmartCharger.Business.Services
             }
         }
 
-        public async Task<ResponseBaseDTO> VerifyCard(string cardValue)
+        public async Task<CardsResponseDTO> VerifyCard(string cardValue)
         {
             try
             {
-                var card = await _context.Cards.FirstOrDefaultAsync(c => c.Value == cardValue);
+                var card = await _context.Cards
+                    .Include(c => c.User)
+                    .FirstOrDefaultAsync(c => c.Value == cardValue);
 
                 if (card == null)
                 {
-                    return new ResponseBaseDTO
+                    return new CardsResponseDTO
                     {
                         Success = false,
-                        Message = "RFID card with that value doesn't exist.",
+                        Message = "RFID card with that value doesn't exist."
                     };
                 }
 
                 if (card.Active == false)
                 {
-                    return new ResponseBaseDTO
+                    return new CardsResponseDTO
                     {
                         Success = false,
-                        Message = "RFID card with name " + card.Name + " is not active.",
+                        Message = "RFID card with name " + card.Name + " is not active."
                     };
                 }
 
                 if (card.UsageStatus == true)
                 {
-                    return new ResponseBaseDTO
+                    return new CardsResponseDTO
                     {
                         Success = false,
-                        Message = "RFID card with name " + card.Name + " is already in use.",
+                        Message = "RFID card with name " + card.Name + " is already in use."
                     };
                 }
 
-                return new ResponseBaseDTO
+                return new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "RFID card with name " + card.Name + " is accepted.",
+                    Message = "RFID card is accepted.",
+                    Card = MapCardToDTO(card)
                 };
             }
             catch (Exception ex)

--- a/SmartCharger.Data/Entities/Card.cs
+++ b/SmartCharger.Data/Entities/Card.cs
@@ -7,6 +7,7 @@ namespace SmartCharger.Data.Entities
         public string Value { get; set; }
         public bool Active { get; set; }
         public string Name { get; set; }
+        public bool UsageStatus { get; set; }
 
         [ForeignKey(nameof(User))]
         public int UserId { get; set; }

--- a/SmartCharger.Data/Migrations/20231129063802_addedUsageStatusToCard.Designer.cs
+++ b/SmartCharger.Data/Migrations/20231129063802_addedUsageStatusToCard.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartCharger.Data;
@@ -11,9 +12,11 @@ using SmartCharger.Data;
 namespace SmartCharger.Data.Migrations
 {
     [DbContext(typeof(SmartChargerContext))]
-    partial class SmartChargerContextModelSnapshot : ModelSnapshot
+    [Migration("20231129063802_addedUsageStatusToCard")]
+    partial class addedUsageStatusToCard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SmartCharger.Data/Migrations/20231129063802_addedUsageStatusToCard.cs
+++ b/SmartCharger.Data/Migrations/20231129063802_addedUsageStatusToCard.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartCharger.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class addedUsageStatusToCard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UsageStatus",
+                table: "Cards",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UsageStatus",
+                table: "Cards");
+        }
+    }
+}

--- a/SmartCharger.Test/ControllerTests/CardControllerTests.cs
+++ b/SmartCharger.Test/ControllerTests/CardControllerTests.cs
@@ -566,10 +566,24 @@ namespace SmartCharger.Test.ControllerTests
             // Arrange
             var cardServiceMock = new Mock<ICardService>();
             cardServiceMock.Setup(service => service.VerifyCard(It.IsAny<string>()))
-                .ReturnsAsync(new ResponseBaseDTO
+                .ReturnsAsync(new CardsResponseDTO
                 {
                     Success = true,
-                    Message = "RFID card with name Card 1 is accepted."
+                    Message = "RFID card is accepted.",
+                    Card = new CardDTO
+                    {
+                        Id = 1,
+                        Name = "Card 1",
+                        Value = "RFID-ST34-56UV-7890",
+                        Active = true,
+                        User = new UserDTO
+                        {
+                            Id = 1,
+                            FirstName = "Ivo",
+                            LastName = "Ivic",
+                            Email = ""
+                        }
+                    }
                 });
 
             var controller = new CardController(cardServiceMock.Object);
@@ -583,7 +597,7 @@ namespace SmartCharger.Test.ControllerTests
             Assert.Equal(200, result.StatusCode);
             var response = result.Value as ResponseBaseDTO;
             Assert.True(response.Success);
-            Assert.Equal("RFID card with name Card 1 is accepted.", response.Message);
+            Assert.Equal("RFID card is accepted.", response.Message);
         }
 
         [Fact]
@@ -592,7 +606,7 @@ namespace SmartCharger.Test.ControllerTests
             // Arrange
             var cardServiceMock = new Mock<ICardService>();
             cardServiceMock.Setup(service => service.VerifyCard(It.IsAny<string>()))
-                .ReturnsAsync(new ResponseBaseDTO
+                .ReturnsAsync(new CardsResponseDTO
                 {
                     Success = false,
                     Message = "RFID card with name Card 1 is not active."

--- a/SmartCharger.Test/ServicesTests/CardServiceTests.cs
+++ b/SmartCharger.Test/ServicesTests/CardServiceTests.cs
@@ -450,11 +450,12 @@ namespace SmartCharger.Test.ServicesTests
                 CardService cardService = new CardService(context);
 
                 // Act
-                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+                CardsResponseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
 
                 // Assert
                 Assert.True(result.Success);
-                Assert.Equal("RFID card with name Card 1 is accepted.", result.Message);
+                Assert.Equal("RFID card is accepted.", result.Message);
+                Assert.Equal("RFID-ST34-56UV-7890", result.Card.Value);
             }
         }
 
@@ -478,7 +479,7 @@ namespace SmartCharger.Test.ServicesTests
                 CardService cardService = new CardService(context);
 
                 // Act
-                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+                CardsResponseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
 
                 // Assert
                 Assert.False(result.Success);
@@ -506,7 +507,7 @@ namespace SmartCharger.Test.ServicesTests
                 CardService cardService = new CardService(context);
 
                 // Act
-                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+                CardsResponseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
 
                 // Assert
                 Assert.False(result.Success);

--- a/SmartCharger.Test/ServicesTests/CardServiceTests.cs
+++ b/SmartCharger.Test/ServicesTests/CardServiceTests.cs
@@ -432,6 +432,109 @@ namespace SmartCharger.Test.ServicesTests
             }
         }
 
+        [Fact]
+        public async Task VerifyCard_WhenCardExistsAndReadyToUse_ShouldReturnSuccess()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase10")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                CardService cardService = new CardService(context);
+
+                // Act
+                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("RFID card with name Card 1 is accepted.", result.Message);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyCard_WhenCardExistsAndIsNotActive_ShouldReturnFailure()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase11")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+                context.Cards.FirstOrDefault().Active = false;
+                context.SaveChanges();
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                CardService cardService = new CardService(context);
+
+                // Act
+                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("RFID card with name Card 1 is not active.", result.Message);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyCard_WhenCardExistsAndIsInUse_ShouldReturnFailure()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "CardServiceDatabase12")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+                context.Cards.FirstOrDefault().UsageStatus = true;
+                context.SaveChanges();
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                CardService cardService = new CardService(context);
+
+                // Act
+                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("RFID card with name Card 1 is already in use.", result.Message);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyCard_WhenCardDoesntExist_ShouldReturnFailure()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+                .UseInMemoryDatabase(databaseName: "empty")
+                .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                CardService cardService = new CardService(context);
+
+                // Act
+                ResponseBaseDTO result = await cardService.VerifyCard("RFID-ST34-56UV-7890");
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal("RFID card with that value doesn't exist.", result.Message);
+            }
+        }
+
         private void SetupDatabase(SmartChargerContext context)
         {
             string salt = BCrypt.Net.BCrypt.GenerateSalt();

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -147,5 +147,18 @@ namespace SmartCharger.Controllers
 
             return Ok(response);
         }
+
+        [HttpGet("/cards/{cardValue}/verify")]
+        public async Task<ActionResult<ResponseBaseDTO>> VerifyCard(string cardValue)
+        {
+            ResponseBaseDTO response = await _cardService.VerifyCard(cardValue);
+
+            if (response.Success == false)
+            {
+                return new ObjectResult(response) { StatusCode = 403 };
+            }
+
+            return Ok(response);
+        }
     }
 }

--- a/SmartCharger/Controllers/CardController.cs
+++ b/SmartCharger/Controllers/CardController.cs
@@ -74,7 +74,7 @@ namespace SmartCharger.Controllers
         }
 
         [Authorize]
-        [HttpGet("/users/{userId}/cards")]
+        [HttpGet("users/{userId}/cards")]
         public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> GetAllCardsForUser(int userId)
         {
             var userIdClaim = User.FindFirst("userId")?.Value;
@@ -93,7 +93,7 @@ namespace SmartCharger.Controllers
         }
 
         [Authorize]
-        [HttpGet("/users/{userId}/cards/{cardId}")]
+        [HttpGet("users/{userId}/cards/{cardId}")]
         public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> GetCardByIdForUser(int cardId, int userId)
         {
             var userIdClaim = User.FindFirst("userId")?.Value;
@@ -112,7 +112,7 @@ namespace SmartCharger.Controllers
         }
 
         [Authorize]
-        [HttpPost("/users/{userId}/cards")]
+        [HttpPost("users/{userId}/cards")]
         public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> AddCard(int userId, [FromBody] AddCardDTO rfidCard)
         {
             var userIdClaim = User.FindFirst("userId")?.Value;
@@ -130,7 +130,7 @@ namespace SmartCharger.Controllers
         }
 
         [Authorize]
-        [HttpDelete("/users/{userId}/cards/{cardId}")]
+        [HttpDelete("users/{userId}/cards/{cardId}")]
         public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> DeleteCardForUser(int cardId, int userId)
         {
             var userIdClaim = User.FindFirst("userId")?.Value;
@@ -148,10 +148,10 @@ namespace SmartCharger.Controllers
             return Ok(response);
         }
 
-        [HttpGet("/cards/{cardValue}/verify")]
-        public async Task<ActionResult<ResponseBaseDTO>> VerifyCard(string cardValue)
+        [HttpGet("cards/{cardValue}/verify")]
+        public async Task<ActionResult<IEnumerable<CardsResponseDTO>>> VerifyCard(string cardValue)
         {
-            ResponseBaseDTO response = await _cardService.VerifyCard(cardValue);
+            CardsResponseDTO response = await _cardService.VerifyCard(cardValue);
 
             if (response.Success == false)
             {


### PR DESCRIPTION
Added RFID card check for user. The feature allows user to verify RFID card before starting charging. RFID card needs to be active and not in use to get successful response. More information on [Confluence](https://mkajic20.atlassian.net/wiki/spaces/BaccBoysSm/pages/8421574)

Changes made:

1. Implemented new method _VerifyCard_ with logic in _**'CardService'**_ in Bussiness layer.
2. Implemented new endpoint for method _VerifyCard_ in _**'CardController'**_ 
3. Added unit tests for _VerifyCard_  in the 'CardService' and 'CardController' to ensure the feature works as expected.

All previous and current tests have successfully passed. ✅