### PR TITLE
Sc 9 implement start and end of charging

### DIFF
--- a/SmartCharger.Business/DTOs/EventChargingDTO.cs
+++ b/SmartCharger.Business/DTOs/EventChargingDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace SmartCharger.Business.DTOs
+{
+    public class EventChargingDTO : BaseDTO
+    {
+        public DateTime StartTime { get; set; }
+        public DateTime? EndTime { get; set; }
+        public double? Volume { get; set; }
+        public int ChargerId { get; set; }
+        public int CardId { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/SmartCharger.Business/DTOs/EventResponseDTO.cs
+++ b/SmartCharger.Business/DTOs/EventResponseDTO.cs
@@ -7,6 +7,6 @@ namespace SmartCharger.Business.DTOs
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<EventDTO>? Events { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public EventDTO? Event { get; set; }
+        public EventChargingDTO? Event { get; set; }
     }
 }

--- a/SmartCharger.Business/DTOs/EventResponseDTO.cs
+++ b/SmartCharger.Business/DTOs/EventResponseDTO.cs
@@ -6,5 +6,7 @@ namespace SmartCharger.Business.DTOs
     {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<EventDTO>? Events { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public EventDTO? Event { get; set; }
     }
 }

--- a/SmartCharger.Business/Interfaces/IEventService.cs
+++ b/SmartCharger.Business/Interfaces/IEventService.cs
@@ -5,7 +5,7 @@ namespace SmartCharger.Business.Interfaces
     public interface IEventService
     {
         Task<EventResponseDTO> GetUsersChargingHistory(int userId, int page, int pageSize, string search);
-        Task<EventResponseDTO> StartCharging(DateTime startTime, int chargerId, int cardId, int userId);
-        Task<EventResponseDTO> EndCharging(int eventId, DateTime endTime, double value);
+        Task<EventResponseDTO> StartCharging(EventChargingDTO eventDTO);
+        Task<EventResponseDTO> EndCharging(EventChargingDTO eventDTO);
     }
 }

--- a/SmartCharger.Business/Interfaces/IEventService.cs
+++ b/SmartCharger.Business/Interfaces/IEventService.cs
@@ -6,6 +6,6 @@ namespace SmartCharger.Business.Interfaces
     {
         Task<EventResponseDTO> GetUsersChargingHistory(int userId, int page, int pageSize, string search);
         Task<EventResponseDTO> StartCharging(DateTime startTime, int chargerId, int cardId, int userId);
-        Task<EventResponseDTO> EndCharging(DateTime endTime, double value);
+        Task<EventResponseDTO> EndCharging(int eventId, DateTime endTime, double value);
     }
 }

--- a/SmartCharger.Business/Interfaces/IEventService.cs
+++ b/SmartCharger.Business/Interfaces/IEventService.cs
@@ -5,5 +5,7 @@ namespace SmartCharger.Business.Interfaces
     public interface IEventService
     {
         Task<EventResponseDTO> GetUsersChargingHistory(int userId, int page, int pageSize, string search);
+        Task<EventResponseDTO> StartCharging(DateTime startTime, int chargerId, int cardId, int userId);
+        Task<EventResponseDTO> EndCharging(DateTime endTime, double value);
     }
 }

--- a/SmartCharger.Business/Services/EventService.cs
+++ b/SmartCharger.Business/Services/EventService.cs
@@ -208,6 +208,7 @@ namespace SmartCharger.Business.Services
                 var chargingEvent = await _context.Events
                     .Include(e => e.Charger)
                     .Include(e => e.Card)
+                    .Include(e => e.User)
                     .SingleOrDefaultAsync(e => e.Id == eventDTO.Id);
 
                 if (chargingEvent == null)
@@ -257,9 +258,9 @@ namespace SmartCharger.Business.Services
                         StartTime = selectedEvent.StartTime,
                         EndTime = selectedEvent.EndTime,
                         Volume = selectedEvent.Volume,
-                        ChargerId = selectedEvent.ChargerId,
-                        CardId = selectedEvent.CardId,
-                        UserId = selectedEvent.UserId
+                        ChargerId = selectedEvent.Charger.Id,
+                        CardId = selectedEvent.Card.Id,
+                        UserId = selectedEvent.User.Id
                     }
                 };
             }

--- a/SmartCharger.Business/Services/EventService.cs
+++ b/SmartCharger.Business/Services/EventService.cs
@@ -115,7 +115,7 @@ namespace SmartCharger.Business.Services
                     return new EventResponseDTO
                     {
                         Success = false,
-                        Message = "Charger with ID: " + charger.Id + " not found."
+                        Message = "Charger with ID: " + chargerId + " not found."
                     };
                 }
                 if (charger.Active == true)
@@ -132,7 +132,7 @@ namespace SmartCharger.Business.Services
                     return new EventResponseDTO
                     {
                         Success = false,
-                        Message = "Card with ID: " + card.Id + " not found."
+                        Message = "Card with ID: " + cardId + " not found."
                     };
                 }
                 if (card.Active == false)
@@ -152,6 +152,14 @@ namespace SmartCharger.Business.Services
                     };
                 }
                 var user = await _context.Users.SingleOrDefaultAsync(c => c.Id == userId);
+                if (user == null)
+                {
+                    return new EventResponseDTO
+                    {
+                        Success = false,
+                        Message = "User with ID: " + userId + " not found."
+                    };
+                }
                 if (user.Active == false)
                 {
                     return new EventResponseDTO
@@ -161,7 +169,7 @@ namespace SmartCharger.Business.Services
                     };
                 }
 
-                var newEvent = new Event
+                Event newEvent = new Event
                 {
                     StartTime = startTime,
                     ChargerId = chargerId,

--- a/SmartCharger.Business/Services/EventService.cs
+++ b/SmartCharger.Business/Services/EventService.cs
@@ -104,5 +104,15 @@ namespace SmartCharger.Business.Services
                 };
             }
         }
+
+        public async Task<EventResponseDTO> StartCharging(DateTime startTime, int chargerId, int cardId, int userId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<EventResponseDTO> EndCharging(DateTime endTime, double value)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SmartCharger.Test/ControllerTests/EventControllerTests.cs
+++ b/SmartCharger.Test/ControllerTests/EventControllerTests.cs
@@ -148,5 +148,162 @@ namespace SmartCharger.Test.ControllerTests
             Assert.Equal("There are no events with that parameters.", response.Message);
             Assert.Null(response.Events);
         }
+
+        [Fact]
+        public async Task StartCharging_WhenEventServiceReturnsSuccess_ShouldReturnOk()
+        {
+            //Arrange
+            var eventServiceMock = new Mock<IEventService>();
+            eventServiceMock.Setup(service => service.StartCharging(It.IsAny<EventChargingDTO>())).ReturnsAsync(
+                new EventResponseDTO
+                {
+                    Success = true,
+                    Message = "Charging started.",
+                    Event = new EventChargingDTO
+                    {
+                        Id = 1,
+                        StartTime = DateTime.Now.ToUniversalTime(),
+                        ChargerId = 1,
+                        CardId = 1,
+                        UserId = 1
+                    }
+                });
+
+            var controller = new EventController(eventServiceMock.Object);
+
+            //Act
+            var actionResult = await controller.StartCharging(new EventChargingDTO
+            {
+                StartTime = DateTime.Now.ToUniversalTime(),
+                ChargerId = 1,
+                CardId = 1,
+                UserId = 1
+            });
+
+            //Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as EventResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("Charging started.", response.Message);
+            Assert.Equal(response.Event.Id, 1);
+        }
+
+        [Fact]
+        public async Task StartCharging_WhenEventServiceReturnsFailure_ShouldReturnBadRequest()
+        {
+            //Arrange
+            var eventServiceMock = new Mock<IEventService>();
+            eventServiceMock.Setup(service => service.StartCharging(It.IsAny<EventChargingDTO>())).ReturnsAsync(
+                new EventResponseDTO
+                {
+                    Success = false,
+                    Message = "Charger is already in use.",
+                    Event = null
+                });
+
+            var controller = new EventController(eventServiceMock.Object);
+
+            //Act
+            var actionResult = await controller.StartCharging(new EventChargingDTO
+            {
+                StartTime = DateTime.Now.ToUniversalTime(),
+                ChargerId = 1,
+                CardId = 1,
+                UserId = 1
+            });
+
+            //Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as EventResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("Charger is already in use.", response.Message);
+            Assert.Null(response.Event);
+        }
+
+        [Fact]
+        public async Task EndCharging_WhenEventServiceReturnsSuccess_ShouldReturnOk()
+        {
+            //Arrange
+            var eventServiceMock = new Mock<IEventService>();
+            eventServiceMock.Setup(service => service.EndCharging(It.IsAny<EventChargingDTO>())).ReturnsAsync(
+                new EventResponseDTO
+                {
+                    Success = true,
+                    Message = "Charging has ended.",
+                    Event = new EventChargingDTO
+                    {
+                        Id = 1,
+                        StartTime = DateTime.Now.ToUniversalTime(),
+                        EndTime = DateTime.Now.ToUniversalTime(),
+                        ChargerId = 1,
+                        CardId = 1,
+                        UserId = 1
+                    }
+                });
+
+            var controller = new EventController(eventServiceMock.Object);
+
+            //Act
+            var actionResult = await controller.EndCharging(new EventChargingDTO
+            {
+                StartTime = DateTime.Now.ToUniversalTime(),
+                EndTime = DateTime.Now.ToUniversalTime(),
+                ChargerId = 1,
+                CardId = 1,
+                UserId = 1
+            });
+
+            //Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(200, result.StatusCode);
+            var response = result.Value as EventResponseDTO;
+            Assert.NotNull(response);
+            Assert.True(response.Success);
+            Assert.Equal("Charging has ended.", response.Message);
+            Assert.Equal(response.Event.Id, 1);
+        }
+
+        [Fact]
+        public async Task EndCharging_WhenEventServiceReturnsFailure_ShouldReturnBadRequest()
+        {
+            //Arrange
+            var eventServiceMock = new Mock<IEventService>();
+            eventServiceMock.Setup(service => service.EndCharging(It.IsAny<EventChargingDTO>())).ReturnsAsync(
+                new EventResponseDTO
+                {
+                    Success = false,
+                    Message = "Charging has already ended.",
+                    Event = null
+                });
+
+            var controller = new EventController(eventServiceMock.Object);
+
+            //Act
+            var actionResult = await controller.EndCharging(new EventChargingDTO
+            {
+                StartTime = DateTime.Now.ToUniversalTime(),
+                EndTime = DateTime.Now.ToUniversalTime(),
+                ChargerId = 1,
+                CardId = 1,
+                UserId = 1
+            });
+
+            //Assert
+            Assert.NotNull(actionResult);
+            var result = actionResult.Result as ObjectResult;
+            Assert.Equal(400, result.StatusCode);
+            var response = result.Value as EventResponseDTO;
+            Assert.NotNull(response);
+            Assert.False(response.Success);
+            Assert.Equal("Charging has already ended.", response.Message);
+            Assert.Null(response.Event);
+        }
     }
 }

--- a/SmartCharger.Test/ServicesTests/EventServiceTests.cs
+++ b/SmartCharger.Test/ServicesTests/EventServiceTests.cs
@@ -109,6 +109,244 @@ namespace SmartCharger.Test.ServicesTests
             }
         }
 
+        [Fact]
+        public async Task StartCharging_WhenEverythingIsOk_ShouldReturnSuccess()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseStart")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.StartCharging(new EventChargingDTO
+                {
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    ChargerId = 1,
+                    CardId = 1,
+                    UserId = 1
+                });
+
+                Assert.True(result.Success);
+                Assert.Equal("Charging started.", result.Message);
+                Assert.Equal(1, result.Event.ChargerId);
+                Assert.Equal(1, result.Event.CardId);
+                Assert.Equal(1, result.Event.UserId);
+            }
+        }
+
+        [Fact]
+        public async Task StartCharging_WhenUserIsNotActive_ShouldReturnFailure()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseStartFail1")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.StartCharging(new EventChargingDTO
+                {
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    ChargerId = 1,
+                    CardId = 2,
+                    UserId = 3
+                });
+
+                Assert.False(result.Success);
+                Assert.Equal("User is not active.", result.Message);
+                Assert.Null(result.Event);
+            }
+        }
+
+        [Fact]
+        public async Task StartCharging_WhenCardIsNotActive_ShouldReturnFailure()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseStartFail2")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.StartCharging(new EventChargingDTO
+                {
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    ChargerId = 1,
+                    CardId = 3,
+                    UserId = 3
+                });
+
+                Assert.False(result.Success);
+                Assert.Equal("RFID card is not active.", result.Message);
+                Assert.Null(result.Event);
+            }
+        }
+
+        [Fact]
+        public async Task StartCharging_WhenCardIsAlreadyInUse_ShouldReturnFailure()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseStartFail3")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.StartCharging(new EventChargingDTO
+                {
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    ChargerId = 1,
+                    CardId = 4,
+                    UserId = 3
+                });
+
+                Assert.False(result.Success);
+                Assert.Equal("RFID card is already in use.", result.Message);
+                Assert.Null(result.Event);
+            }
+        }
+
+        [Fact]
+        public async Task StartCharging_WhenChargerIsAlreadyInUse_ShouldReturnFailure()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseStartFail4")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.StartCharging(new EventChargingDTO
+                {
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    ChargerId = 3,
+                    CardId = 1,
+                    UserId = 1
+                });
+
+                Assert.False(result.Success);
+                Assert.Equal("Charger is already in use.", result.Message);
+                Assert.Null(result.Event);
+            }
+        }
+
+        [Fact]
+        public async Task EndCharging_WhenEverythingIsOk_ShouldReturnSuccess()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseEnd")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.EndCharging(new EventChargingDTO
+                {
+                    Id = 2,
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    EndTime = DateTime.Now.ToUniversalTime(),
+                    Volume = 12,
+                    ChargerId = 3,
+                    CardId = 1,
+                    UserId = 1
+                });
+
+                Assert.True(result.Success);
+                Assert.Equal("Charging has ended.", result.Message);
+                Assert.Equal(2, result.Event.Id);
+                Assert.Equal(12, result.Event.Volume);
+                Assert.Equal(3, result.Event.ChargerId);
+                Assert.Equal(1, result.Event.CardId);
+                Assert.Equal(1, result.Event.UserId);
+            }
+        }
+
+        [Fact]
+        public async Task EndCharging_WhenChargingAlreadyEnded_ShouldReturnFailure()
+        {
+
+            //Arrange
+            var options = new DbContextOptionsBuilder<SmartChargerContext>()
+               .UseInMemoryDatabase(databaseName: "EventServiceDatabaseEndFail1")
+               .Options;
+
+            using (var context = new SmartChargerContext(options))
+            {
+                SetupDatabase(context);
+            }
+
+            using (var context = new SmartChargerContext(options))
+            {
+
+                var eventService = new EventService(context);
+
+                EventResponseDTO result = await eventService.EndCharging(new EventChargingDTO
+                {
+                    Id = 1,
+                    StartTime = DateTime.Now.ToUniversalTime(),
+                    EndTime = DateTime.Now.ToUniversalTime(),
+                    Volume = 123,
+                    ChargerId = 1,
+                    CardId = 1,
+                    UserId = 1
+                });
+
+                Assert.False(result.Success);
+                Assert.Equal("Charging has already ended.", result.Message);
+                Assert.Null(result.Event);
+            }
+        }
+
         private void SetupDatabase(SmartChargerContext context)
         {
             string salt = BCrypt.Net.BCrypt.GenerateSalt();
@@ -127,7 +365,18 @@ namespace SmartCharger.Test.ServicesTests
                 RoleId = 2
             });
 
-
+            context.Users.Add(new User
+            {
+                Id = 3,
+                FirstName = "Pero",
+                LastName = "Peric",
+                Email = "pperic@example.com",
+                Password = hashedPassword,
+                Active = false,
+                CreationTime = DateTime.Now.ToUniversalTime(),
+                Salt = salt,
+                RoleId = 2
+            });
 
             context.Chargers.Add(new Charger
             {
@@ -136,6 +385,17 @@ namespace SmartCharger.Test.ServicesTests
                 Latitude = 50,
                 Longitude = 40,
                 CreationTime = DateTime.Now.ToUniversalTime(),
+                Active = false,
+                CreatorId = 1
+            });
+
+            context.Chargers.Add(new Charger
+            {
+                Id = 3,
+                Name = "Charger 3",
+                Latitude = 40,
+                Longitude = 50,
+                CreationTime = DateTime.Now.ToUniversalTime(),
                 Active = true,
                 CreatorId = 1
             });
@@ -143,12 +403,42 @@ namespace SmartCharger.Test.ServicesTests
 
             context.Cards.Add(new Card
             {
+                Id = 1,
                 Value = "RFID-ST34-56UV-7890",
                 Active = true,
+                UsageStatus = false,
                 Name = "Card 1",
                 UserId = 1
             });
 
+
+            context.Cards.Add(new Card
+            {
+                Id = 2,
+                Value = "RFID-AF32-32DA-3219",
+                Active = true,
+                UsageStatus = false,
+                Name = "Card 2",
+                UserId = 3
+            });
+            context.Cards.Add(new Card
+            {
+                Id = 3,
+                Value = "RFID-FJ32-42DA-4812",
+                Active = false,
+                UsageStatus = false,
+                Name = "Card 3",
+                UserId = 3
+            });
+            context.Cards.Add(new Card
+            {
+                Id = 4,
+                Value = "RFID-FJ32-42DA-4812",
+                Active = true,
+                UsageStatus = true,
+                Name = "Card 4",
+                UserId = 3
+            });
 
 
             context.Events.Add(new Event
@@ -159,6 +449,15 @@ namespace SmartCharger.Test.ServicesTests
                 Volume = 123,
                 UserId =1,
                 ChargerId = 1,
+                CardId = 1
+            });
+
+            context.Events.Add(new Event
+            {
+                Id = 2,
+                StartTime = DateTime.Now.ToUniversalTime(),
+                UserId = 1,
+                ChargerId = 3,
                 CardId = 1
             });
 

--- a/SmartCharger/Controllers/EventController.cs
+++ b/SmartCharger/Controllers/EventController.cs
@@ -7,7 +7,7 @@ using SmartCharger.Business.Services;
 
 namespace SmartCharger.Controllers
 {
-    [Route("api/users/")]
+    [Route("api/")]
     [ApiController]
     public class EventController : ControllerBase
     {
@@ -20,10 +20,22 @@ namespace SmartCharger.Controllers
         }
 
         [Authorize(Policy = "AdminOrCustomer")]
-        [HttpGet("{userId}/history")]
+        [HttpGet("users/{userId}/history")]
         public async Task<ActionResult<IEnumerable<EventResponseDTO>>> GetUsersChargingHistory(int userId, [FromQuery] int page = 1, [FromQuery] int pageSize = 5, [FromQuery] string search = null)
         {
             EventResponseDTO response = await _eventService.GetUsersChargingHistory(userId, page, pageSize, search);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        [HttpPost("events/start")]
+        public async Task<ActionResult<IEnumerable<EventResponseDTO>>> StartCharging([FromBody] EventChargingDTO eventDTO)
+        {
+            EventResponseDTO response = await _eventService.StartCharging(eventDTO.StartTime, eventDTO.ChargerId, eventDTO.CardId, eventDTO.UserId);
             if (response.Success == false)
             {
                 return BadRequest(response);

--- a/SmartCharger/Controllers/EventController.cs
+++ b/SmartCharger/Controllers/EventController.cs
@@ -35,7 +35,19 @@ namespace SmartCharger.Controllers
         [HttpPost("events/start")]
         public async Task<ActionResult<IEnumerable<EventResponseDTO>>> StartCharging([FromBody] EventChargingDTO eventDTO)
         {
-            EventResponseDTO response = await _eventService.StartCharging(eventDTO.StartTime, eventDTO.ChargerId, eventDTO.CardId, eventDTO.UserId);
+            EventResponseDTO response = await _eventService.StartCharging(eventDTO);
+            if (response.Success == false)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        [HttpPatch("events/stop")]
+        public async Task<ActionResult<IEnumerable<EventResponseDTO>>> EndCharging([FromBody] EventChargingDTO eventDTO)
+        {
+            EventResponseDTO response = await _eventService.EndCharging(eventDTO);
             if (response.Success == false)
             {
                 return BadRequest(response);


### PR DESCRIPTION
The feature allows user to start and end charging. Start charging has to check if charger is already in use before starting charging so as if RFID card is active and not in use and if user is disabled. More information on [Confluence ](https://mkajic20.atlassian.net/wiki/spaces/BaccBoysSm/pages/8454419)

Changes made:

1. Added _EventChargingDTO_ and modified _EventResponseDTO_ 
2. Implemented new methods _StartCharging_ and _EndCharging_ with logic in _**'EventService'**_ in Bussiness layer.
3. Implemented new endpoints for _StartCharging_ and _EndCharging_ in _**'EventController'**_
4. Added unit tests for _StartCharging_ and _EndCharging_  in the _**'EventService'**_ and _**'EventController'**_ to ensure the feature works as expected.

All previous and current tests have successfully passed. ✅